### PR TITLE
Add README for node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ JAPER is a security-focused platform that helps developers manage devices, valid
 
 `/v1/x/validation/status` Check a JAPER Customer's opt-out status.
 
+## Examples
+
+The [examples/node](examples/node) folder contains a simple Node.js script.
+Set the `NODE_API_KEY` environment variable and run `node ping.js` to
+ping the API.
+
 ## Contributing and Feedback
 
 Contributions are welcome! Feel free to open issues or submit pull requests if you find problems or want to suggest improvements. For direct feedback, use the contact information on [developer.japer.io](https://developer.japer.io).

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -1,0 +1,16 @@
+# Node Example
+
+This folder contains a simple script to ping the JAPER API.
+
+## Requirements
+
+- Set the `NODE_API_KEY` environment variable with your API key.
+
+## Usage
+
+Run the script:
+
+```bash
+node ping.js
+```
+


### PR DESCRIPTION
## Summary
- document Node example usage and env var in `examples/node/README.md`
- mention Node example in the main README

## Testing
- `NODE_API_KEY=foo node examples/node/ping.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_b_687781b842f08325add999f0fe57a152