### PR TITLE
Add Node example package.json

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "japer-node-example",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "start": "node ping.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add npm configuration for `examples/node`

## Testing
- `npm start` in `examples/node` (fails due to missing `NODE_API_KEY`)


------
https://chatgpt.com/codex/tasks/task_b_687781bc0db48325aa9e1183d5502814